### PR TITLE
Avoid blocking domains that should be allowed

### DIFF
--- a/scripts/lib/addressMaker.class.php
+++ b/scripts/lib/addressMaker.class.php
@@ -95,7 +95,7 @@ class addressMaker{
                 continue;
             }
 
-            if(preg_match('/^\|\|([0-9a-z\-\.]+[a-z]+)\^(\$([^=]+?,)?(image|third-party|script)(,[^=]+)?)?$/', $line, $matches)){
+            if(preg_match('/^\|\|([0-9a-z\-\.]+[a-z]+)\^(\$([^=~]+?,)?(image|third-party|script)(,[^=~]+)?)?$/', $line, $matches)){
 
                 if(substr($matches[1], 0, 4) == 'www.'){
                     $row = substr($matches[1], 4);


### PR DESCRIPTION
在easylist的语法中，形如`||example.com^$~image`表示拦截来自`example.com`的所有连接除非是`image`类型，也就是放行来自`example.com`的`image`。那么anti-ad作为域名级的拦截列表应该放过`example.com`。

原脚本中的正则判断：

```php
if(preg_match('/^\|\|([0-9a-z\-\.]+[a-z]+)\^(\$([^=]+?,)?(image|third-party|script)(,[^=]+)?)?$/', $line, $matches))
```

没有涉及到`~`这一字符。`||example.com^$~image,script^`这类上游规则符合此处判断条件，其中的域名会被anti-ad拦截。实际上已有这样的例子，比如目前`||bestcontactform.com^$~image,third-party`中的`bestcontactform.com`，`||70e.com^$third-party,~script`中的`70e.com`被拦截了。

这一PR能修复此问题。